### PR TITLE
5 December R1

### DIFF
--- a/activity/activity.go
+++ b/activity/activity.go
@@ -1,30 +1,32 @@
 package activity
 
 import (
-	"time"
-
+	"fmt"
 	"github.com/tolexo/aero/activity/model"
 	"github.com/tolexo/aero/db/tmongo"
-	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2"
+	"time"
 )
 
 const (
-	DB_CONTAINER = "database.omni"
+	DB_CONTAINER = "database.activity"
 )
 
 //Log User activity
 func LogActivity(url string, body interface{},
 	resp interface{}, respCode int, respTime float64) {
+	sTime := time.Now()
 	apiDetail := model.APIDetail{
 		Url:      url,
 		Body:     body,
 		Resp:     resp,
 		RespCode: respCode,
 		RespTime: respTime,
-		Time:     time.Now(),
+		Time:     sTime,
 	}
 	if sess, mdb, err := tmongo.GetMongoConn(DB_CONTAINER); err == nil {
 		defer sess.Close()
+		mdb = fmt.Sprintf("%v_%v_%v_%v", mdb, sTime.Day(), sTime.Month(), sTime.Year())
 		sess.SetSafe(&mgo.Safe{W: 0})
 		sess.DB(mdb).C("activity").Insert(apiDetail)
 	}

--- a/activity/activity.go
+++ b/activity/activity.go
@@ -13,16 +13,17 @@ const (
 )
 
 //Log User activity
-func LogActivity(url string, body interface{},
+func LogActivity(url string, serviceID string, body interface{},
 	resp interface{}, respCode int, respTime float64) {
 	sTime := time.Now()
 	apiDetail := model.APIDetail{
-		Url:      url,
-		Body:     body,
-		Resp:     resp,
-		RespCode: respCode,
-		RespTime: respTime,
-		Time:     sTime,
+		Url:       url,
+		ServiceID: serviceID,
+		Body:      body,
+		Resp:      resp,
+		RespCode:  respCode,
+		RespTime:  respTime,
+		Time:      sTime,
 	}
 	if sess, mdb, err := tmongo.GetMongoConn(DB_CONTAINER); err == nil {
 		defer sess.Close()

--- a/activity/model/apiDetail.go
+++ b/activity/model/apiDetail.go
@@ -4,10 +4,11 @@ import "time"
 
 //Complete API detail
 type APIDetail struct {
-	Url      string      `bson:"url"`
-	Body     interface{} `bson:"body"`
-	Resp     interface{} `bson:"response"`
-	RespCode int         `bson:"response_code"`
-	RespTime float64     `bson:"response_time"`
-	Time     time.Time   `bson:"time"`
+	Url       string      `bson:"url"`
+	ServiceID string      `bson:"service"`
+	Body      interface{} `bson:"body"`
+	Resp      interface{} `bson:"response"`
+	RespCode  int         `bson:"response_code"`
+	RespTime  float64     `bson:"response_time"`
+	Time      time.Time   `bson:"time"`
 }


### PR DESCRIPTION
PRA-RESTORE - Tally Sync Restore
PRA-655 - Update Phone no data validation
PRA-663 - Address update for adding & update
PRA-606 - LR, Invoice, Challan Filter
PRA-410A - Capture User Activity for log tag only
PRA-105I - Tally Updates
PRA-25-PRA-606 - show warehouse and a warehouse filter drop down option on screen 3
PRA-25-PRA-606 - As a Poora Seller/Seller User, I should be able to filter packs basis on Challan/Invoice is generated/not generated/all on In-Packing screen
PRA-25-PRA-606 - As a Poora Seller/Seller User, I should be able to filter packs basis on Challan/Invoice is generated/not generated/all on In-Packing screen
PRA-649 - Add tally Status in listing product
PRA-658 - Update Search of customer
PRA-662 - Disable Product
PRA-651 - Tally Bug -On click of "Map to customers" there is no Close button to close that expanded view.